### PR TITLE
Add logging, frequency correction, and FM scan tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project is an FM transmitter based on the ESP32-C3 microcontroller and the 
 - Frequency presets sorted by frequency
 - Web interface via Wi-Fi Access Point (no password by default)
 - Frequency correction offset
-- Scan FM band and view noise levels
+- Scan FM band and view noise levels (transmission pauses during scan)
 - Built with PlatformIO for Arduino framework
 
 ## Hardware Requirements

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ This project is an FM transmitter based on the ESP32-C3 microcontroller and the 
 - Frequency presets sorted by frequency
 - Web interface via Wi-Fi Access Point (no password by default)
 - Frequency correction offset
-- Scan FM band and view noise levels (transmission pauses during scan)
 - Built with PlatformIO for Arduino framework
 
 ## Hardware Requirements

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ This project is an FM transmitter based on the ESP32-C3 microcontroller and the 
 - Control FM frequency (range: 80.00–110.00 MHz)
 - Power on/off the transmitter
 - Select from preset frequencies
+- Frequency presets sorted by frequency
 - Web interface via Wi-Fi Access Point (no password by default)
+- Frequency correction offset
+- Scan FM band and view noise levels
 - Built with PlatformIO for Arduino framework
 
 ## Hardware Requirements

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -192,12 +192,11 @@ void cbTxPower(Control *sender, int type)
 
 void cbFreqCorr(Control *sender, int type)
 {
-    if (type == S_VALUE)
+    if (type == N_VALUE)
     {
         freq_correction_khz = (int16_t)sender->value.toInt();
         Serial.printf("[cbFreqCorr] %d kHz\n", freq_correction_khz);
-        if (radioOn && radioFound)
-            applyTune(freq_tenths);
+        applyTune(freq_tenths); // retune with new correction
     }
 }
 


### PR DESCRIPTION
## Summary
- add serial logging across radio functions and UI callbacks
- sort preset stations by frequency and allow frequency correction offset
- introduce FM band scanner tab with configurable sweep

## Testing
- `platformio run`

------
https://chatgpt.com/codex/tasks/task_e_68aaa0cf99248333b1298f1fcaba696f